### PR TITLE
FIX Missing app name. Corresponding semver bump.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open('README.md') as f:
 
 setup(
     name='wagtail_events',
-    version='0.2.7',
+    version='0.3.0',
     description='Event pages for Wagtail',
     long_description=readme_text,
     long_description_content_type="text/markdown",

--- a/wagtail_events/apps.py
+++ b/wagtail_events/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+from django.utils.translation import gettext_lazy as _
+
+
+class WagtailEventsAppConfig(AppConfig):
+    name = 'wagtail_references'
+    label = 'wagtail_references'
+    verbose_name = _('Wagtail References')


### PR DESCRIPTION
Fixes issue #9 by adding an app_name field with corresponding semver bump.

